### PR TITLE
Handle the users list to prepare

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,9 @@
         "Dockerfile*": "dockerfile",
       },
     "objectscript.conn" :{
-      "ns": "IRISAPP",
+      "ns": "USER",
+      "username": "_SYSTEM",
+      "password": "SYS",
       "active": true,
       "docker-compose": {
         "service": "iris",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE=intersystemsdc/iris-community:2021.1.0.215.3-zpm
+ARG IMAGE=intersystemsdc/iris-community:latest
 FROM $IMAGE
 
 USER root

--- a/module.xml
+++ b/module.xml
@@ -3,7 +3,7 @@
   <Document name="isc-apptools-lockdown.ZPM">
     <Module>
       <Name>isc-apptools-lockdown</Name>
-      <Version>1.0.15</Version>
+      <Version>1.0.16</Version>
       <Description>Program for changing the security level of the system.</Description>
 	  <Keywords>lockdown admin</Keywords>
 		<Author>

--- a/src/cls/appmsw/security/lockdown.cls
+++ b/src/cls/appmsw/security/lockdown.cls
@@ -6,6 +6,8 @@ Parameter GN = "^appmsw.security.lockdown";
 
 Parameter GNcustom = "^appmsw.security.custom";
 
+Parameter DefaultUserList = "Admin,CSPSystem,IAM,SuperUser,UnknownUser,_Ensemble,_SYSTEM";
+
 /// do ##class(appmsw.security.lockdown).SetSecurityLevel("minimum","SYS")
 /// do ##class(appmsw.security.lockdown).SetSecurityLevel("normal","Normal321level")
 /// do ##class(appmsw.security.lockdown).SetSecurityLevel("lockdown","Lockdown321level")
@@ -295,7 +297,28 @@ ClassMethod Apply(newPassword = "", Warn, sBindings = "", sCachedirect = "", Ina
 /// do ##class(appmsw.security.lockdown).GetPreparedUsers()
 ClassMethod GetPreparedUsers() As %String
 {
-  quit "Admin,CSPSystem,IAM,SuperUser,UnknownUser,_Ensemble,_SYSTEM"
+  	Quit:$Data(%zLockDown("users"), users) users
+	Quit ..#DefaultUserList
+}
+
+ClassMethod PrepareUsers(users As %String = {..#DefaultUserList}, exclude As %String = "") As %Status
+{
+	If exclude = "" Set %zLockDown("users") = users Quit $$$OK
+
+	Set lbUsers = $ListFromString(users), lbExclude = $ListFromString(exclude), ptr = 0, prepareUsers = ""
+
+	While $ListNext(lbUsers, ptr, user) {
+		Set:'$LISTFIND(lbExclude, user) $Piece(prepareUsers, ",", $Increment(pos)) = user
+	}
+
+	Set %zLockDown("users") = prepareUsers
+	Quit $$$OK
+}
+
+ClassMethod ResetPreparedUsersList() As %Status
+{
+	Kill %zLockDown("users")
+	Quit $$$OK
 }
 
 /// Change password for userlist
@@ -576,4 +599,3 @@ ClassMethod SaveProj(path) As %Status
 }
 
 }
-


### PR DESCRIPTION
Hi @SergeyMi37 ,

I would like to provide an additional feature to your application `isc-apptools-lockdown`.

I need to handle the default user list `Admin,CSPSystem,IAM,SuperUser,UnknownUser,_Ensemble,_SYSTEM`.
Methods are added, if a developer needs to change this default users list, ex : 

1. To set manually the users list:

```
do ##class(appmsw.security.lockdown).PrepareUsers("Admin,CSPSystem,IAM,SuperUser"), ##class(appmsw.security.lockdown).SetSecurityLevel("normal","Normal321level")
```

2. To exclude a user from the default list:
```
do ##class(appmsw.security.lockdown).PrepareUsers(,"CSPSystem"), ##class(appmsw.security.lockdown).SetSecurityLevel("normal","Normal321level")
```

I hope you are ok with this pull request.

BTW, I also fix some problems with VS code settings the iris docker image.

Thank you.
Lorenzo.